### PR TITLE
BUG getList() now returns the filtered DataList

### DIFF
--- a/code/tools/ShortCodeRelationFinder.php
+++ b/code/tools/ShortCodeRelationFinder.php
@@ -49,7 +49,7 @@ class ShortCodeRelationFinder {
 			}
 		}
 
-		$list->where(implode(' OR ',$where));
+		$list = $list->where(implode(' OR ', $where));
 		return $list;
 	}
 


### PR DESCRIPTION
In SilverStripe 3.1.x getList() was returning the unfiltered DataList and as a result all pages in the SiteTree were showing as having a reference to the given document.
