### PR TITLE
BUG: malformed html causing rendering issues in IE8

### DIFF
--- a/templates/DMSDocumentAddExistingField.ss
+++ b/templates/DMSDocumentAddExistingField.ss
@@ -42,9 +42,9 @@
 			<span class="step-label">
 				<% if useFieldContext %>
 					<span class="flyout">2</span><span class="arrow"></span>
-					<span class="title">Edit Document Details</span>
+					<strong class="title">Edit Document Details</strong>
 				<% else %>
-					<label>Selected Document</strong>
+					<label>Selected Document</label>
 				<% end_if %>
 			</span>
 		</div>


### PR DESCRIPTION
This is an urgent fix for a client who uses the cms in IE8. The malformed html was casuing the insert link modal to render as this:

![image002](https://f.cloud.github.com/assets/984753/278784/bd6db34e-90f4-11e2-91d4-6087f61b5554.png)
