### PR TITLE
Updated the add_extension in _config

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -11,8 +11,8 @@ define('DMS_DIR', 'dms');
 
 if (!file_exists(BASE_PATH . DIRECTORY_SEPARATOR . DMS_DIR)) user_error("DMS directory named incorrectly. Please install the DMS module into a folder named: ".DMS_DIR);
 
-Object::add_extension('SiteTree','DMSSiteTreeExtension');
-Object::add_extension('HtmlEditorField_Toolbar','DocumentHtmlEditorFieldToolbar');
+SiteTree::add_extension('DMSSiteTreeExtension');
+HtmlEditorField_Toolbar::add_extension('DocumentHtmlEditorFieldToolbar');
 CMSMenu::remove_menu_item('DMSDocumentAddController');
 
 ShortcodeParser::get('default')->register('dms_document_link', array('DMSDocument_Controller', 'dms_link_shortcode_handler'));


### PR DESCRIPTION
Currently breaking 3.1 sites with error message: Fatal error: Object::add_extension() - Extension "SiteTree" is not a subclass of Extension in /Applications/MAMP/htdocs/nzqa-intranet/framework/core/Object.php on line 467
Is a 3.1 branch required?
