### PR TITLE
Add allowed_actions to make it work for 3.1

### DIFF
--- a/code/cms/DMSGridFieldDetailForm.php
+++ b/code/cms/DMSGridFieldDetailForm.php
@@ -4,7 +4,7 @@
  * Custom ItemRequest class the provides custom delete behaviour for the CMSFields of DMSDocument
  */
 class DMSGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemRequest {
-
+	private static $allowed_actions = array('ItemEditForm');
 
 	function ItemEditForm() {
 		$form = parent::ItemEditForm();


### PR DESCRIPTION
Previously, the subclass of GridFieldDetailForm_ItemRequest didn't have anything to allow the action it used.
