### PR TITLE
3.1 compat -- Add action to allowed_actions

### DIFF
--- a/code/cms/DMSGridFieldDetailForm.php
+++ b/code/cms/DMSGridFieldDetailForm.php
@@ -4,7 +4,7 @@
  * Custom ItemRequest class the provides custom delete behaviour for the CMSFields of DMSDocument
  */
 class DMSGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemRequest {
-
+	private static $allowed_actions = array('ItemEditForm');
 
 	function ItemEditForm() {
 		$form = parent::ItemEditForm();


### PR DESCRIPTION
When subclassing in 3.1, you are required to add to allowed_actions for any method you redefine. Such is the case here.
