### PR TITLE
FIX Don't show the upload field when inappropriate

### DIFF
--- a/code/cms/DMSUploadField.php
+++ b/code/cms/DMSUploadField.php
@@ -57,6 +57,15 @@ class DMSUploadField extends UploadField {
 		return true;
 	}
 
+
+	public function isDisabled() {
+		return (parent::isDisabled() || !$this->isSaveable());
+	}
+
+	public function isSaveable() {
+		return (!empty($this->getRecord()->ID));
+	}
+
 	/**
 	 * Action to handle upload of a single file
 	 * 


### PR DESCRIPTION
This fix is quite ugly, but in theory, it's fine. By ugly, I mean the interface is kind of weird without it.
Because 3.1 allows uploading when a DataObject doesn't exist, we need to override the new defaults to not allow such if the DO isn't saved yet.

Testing for this would be much appreciated. It seems okay to me, but I can imagine some edge cases.
