### PR TITLE
Extend content controller to make sure the correct stage is used.

### DIFF
--- a/code/DMSDocument.php
+++ b/code/DMSDocument.php
@@ -804,7 +804,7 @@ class DMSDocument extends DataObject implements DMSDocumentInterface {
 
 }
 
-class DMSDocument_Controller extends Controller {
+class DMSDocument_Controller extends ContentController {
 
 	static $testMode = false;   //mode to switch for testing. Does not return document download, just document URL
 


### PR DESCRIPTION
The staging system is initialised inside ContentController::init(). As
the DMS serving bypassed this, the stage was not set correctly, meaning
permissions were not always correctly applied.
