### PR TITLE
BUG: Fix access to documents on the staging site.

### DIFF
--- a/code/DMSDocument.php
+++ b/code/DMSDocument.php
@@ -804,13 +804,18 @@ class DMSDocument extends DataObject implements DMSDocumentInterface {
 
 }
 
-class DMSDocument_Controller extends ContentController {
+class DMSDocument_Controller extends Controller {
 
 	static $testMode = false;   //mode to switch for testing. Does not return document download, just document URL
 
 	private static $allowed_actions = array(
 		'index'
 	);
+
+	public function init() {
+		Versioned::choose_site_stage();
+		parent::init();
+	}
 
 	/**
 	 * Returns the document object from the request object's ID parameter.


### PR DESCRIPTION
The DMS document controller had been changed to subclass ContentController
to correctly initialise the versioned stage. However, this had the side
effect of preventing access to documents when the "Stage" stage
was selected.

ContentController::init() calls the SiteTree::canViewStage() method, which
controls access when on the stage. However, since the data record was
non-existant, the method would always return false, preventing access to
documents.

This fix removes the subclassing of ContentController and just directly
initialises the versioned stage.
