### PR TITLE
FIX: panel hide on Actions click

### DIFF
--- a/javascript/DMSDocumentAddExistingField.js
+++ b/javascript/DMSDocumentAddExistingField.js
@@ -23,6 +23,8 @@
 		                    });
 
 							$('.ss-add-files').append(fnout);
+
+                            $('.ss-add-files').find('.ss-uploadfield-item-edit')._loadIframe();
 						}
 					}
 				);

--- a/javascript/DMSDocumentCMSFields.js
+++ b/javascript/DMSDocumentCMSFields.js
@@ -36,7 +36,7 @@
 		$('#Actions ul li').entwine({
 			onclick: function(e) {
 
-				console.log('LI CLICKED');
+				//console.log('LI CLICKED');
 
 				//add active state to the current button
 				$('#Actions ul li').removeClass('dms-active');
@@ -45,11 +45,11 @@
 
 				//hide all inner field sections
 				var panel = $('.ActionsPanel:first');
-				panel.find('div.fieldgroup-field').hide();
+				panel.find('div.fieldgroup').hide();
 
 				//show the correct group of controls
 				//panel.find('.'+this.data('panel')).closest('div.fieldgroup').show();
-				panel.find('.'+this.data('panel')).show().parents('.fieldgroup-field').show();
+				panel.find('.'+this.data('panel')).show().parents('.fieldgroup').show();
 
 			}
 		});

--- a/javascript/DMSUploadField_addtemplate.js
+++ b/javascript/DMSUploadField_addtemplate.js
@@ -23,7 +23,7 @@ window.tmpl.cache['ss-uploadfield-addtemplate'] = tmpl(
 				'{% } %}' +
 			'</div>' +
 			'{% if (!file.error) { %}' +
-				'<div class="ss-uploadfield-item-editform loading"><iframe frameborder="0" src="{%=file.edit_url%}"></iframe></div>' +
+				'<div class="ss-uploadfield-item-editform loading"><iframe frameborder="0" src="about:blank" data-src="{%=file.edit_url%}"></iframe></div>' +
 			'{% } %}' +
 		'</li>' +
 	'{% } %}'


### PR DESCRIPTION
Within CMS admin, administer document and click on the Action buttons to display the related panel. Hide() in the js does not find the panels to hide them and so as the panels show they stack down the page. This fix hangs the hide() on to the correct class. Also removed a console log form js.
