### PR TITLE
API Add deprecation notices for removed methods in 2.0

### DIFF
--- a/code/cms/DMSDocumentAddController.php
+++ b/code/cms/DMSDocumentAddController.php
@@ -27,6 +27,8 @@ class DMSDocumentAddController extends LeftAndMain
      * Add an array of additional allowed extensions
      * @static
      * @param $array
+     *
+     * @deprecated 2.0 Will be removed in future in favour of YAML configuration
      */
     public static function add_allowed_extensions($array = null)
     {

--- a/code/extensions/DMSSiteTreeExtension.php
+++ b/code/extensions/DMSSiteTreeExtension.php
@@ -18,6 +18,8 @@ class DMSSiteTreeExtension extends DataExtension
      * Do not show the documents tab on the array of pages set here
      * @static
      * @param $mixed Array of page types to not show the Documents tab on
+     *
+     * @deprecated 2.0 Will be removed in favour of YAML configuration
      */
     public static function no_documents_tab($array = array())
     {
@@ -36,6 +38,8 @@ class DMSSiteTreeExtension extends DataExtension
      * still not be shown. If this isn't called, or if it is called with an empty array, all pages will get Document tabs.
      * @static
      * @param $array Array of page types to show the Documents tab on
+     *
+     * @deprecated 2.0 Will be removed in favour of YAML configuration
      */
     public static function show_documents_tab($array = array())
     {
@@ -132,6 +136,8 @@ class DMSSiteTreeExtension extends DataExtension
 
     /**
      * Enforce sorting for frontend
+     *
+     * @deprecated 2.0 Will be removed in future
      */
     public function PageDocuments()
     {

--- a/code/interface/DMSDocumentInterface.php
+++ b/code/interface/DMSDocumentInterface.php
@@ -23,6 +23,8 @@ interface DMSDocumentInterface
      * @abstract
      * @param $pageObject Page object to associate this DMSDocument with
      * @return null
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function addPage($pageObject);
     
@@ -32,6 +34,8 @@ interface DMSDocumentInterface
      * @abstract
      * @param $pageIDs array of page ids used for the page objects associate this DMSDocument with
      * @return null
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function addPages($pageIDs);
 
@@ -47,6 +51,8 @@ interface DMSDocumentInterface
      * Returns a list of the Page objects associated with this DMSDocument
      * @abstract
      * @return DataList
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function getPages();
 
@@ -54,6 +60,8 @@ interface DMSDocumentInterface
      * Removes all associated Pages from the DMSDocument
      * @abstract
      * @return null
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function removeAllPages();
 

--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -164,6 +164,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * @param SiteTree $pageObject Page object to associate this Document with
      *
      * @return DMSDocument
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function addPage($pageObject)
     {
@@ -182,6 +184,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * @param array $pageIDs
      *
      * @return DMSDocument
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function addPages($pageIDs)
     {
@@ -203,6 +207,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * @param SiteTree $pageObject Page object to remove the association to
      *
      * @return DMSDocument
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function removePage($pageObject)
     {
@@ -215,6 +221,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * @see getPages()
      *
      * @return DataList
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function Pages()
     {
@@ -228,6 +236,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * Returns a list of the Page objects associated with this Document.
      *
      * @return DataList
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function getPages()
     {
@@ -238,6 +248,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * Removes all associated Pages from the DMSDocument
      *
      * @return DMSDocument
+     *
+     * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function removeAllPages()
     {


### PR DESCRIPTION
These methods are removed in 2.0.0 (see #112) in favour of using document sets (#95).

This pull request adds deprecation notifications in the PHPDocs to let users be aware of these changes before potentially upgrading. 