### PR TITLE
Add deprecation notices for DMSTag and related methods to be removed in 2.0

### DIFF
--- a/code/interface/DMSDocumentInterface.php
+++ b/code/interface/DMSDocumentInterface.php
@@ -11,7 +11,7 @@ interface DMSDocumentInterface
      * Deletes the DMSDocument, its underlying file, as well as any tags related to this DMSDocument.
      *
      * @todo Can't be applied to classes which already implement the DataObjectInterface (naming conflict)
-     * 
+     *
      * @abstract
      * @return null
      */
@@ -27,7 +27,7 @@ interface DMSDocumentInterface
      * @deprecated 2.0 Will be removed in future in favour of document sets
      */
     public function addPage($pageObject);
-    
+
     /**
      * Associates this DMSDocument with a set of Pages. This method loops through a set of page ids, and then associates this
      * DMSDocument with the individual Page with the each page id in the set
@@ -77,6 +77,8 @@ interface DMSDocumentInterface
      * @param $value String of a metadata value to add (required)
      * @param bool $multiValue Boolean that determines if the category is multi-value or single-value (optional)
      * @return null
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function addTag($category, $value, $multiValue = true);
 
@@ -87,6 +89,8 @@ interface DMSDocumentInterface
      * @param $category String of the metadata category to get
      * @param null $value String of the value of the tag to get
      * @return array of Strings of all the tags or null if there is no match found
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function getTagsList($category, $value = null);
 
@@ -98,6 +102,8 @@ interface DMSDocumentInterface
      * @param $category Category to remove (required)
      * @param null $value Value to remove (optional)
      * @return null
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function removeTag($category, $value = null);
 
@@ -105,6 +111,8 @@ interface DMSDocumentInterface
      * Deletes all tags associated with this DMSDocument.
      * @abstract
      * @return null
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function removeAllTags();
 
@@ -114,12 +122,12 @@ interface DMSDocumentInterface
      * @return String
      */
     public function getLink();
-    
+
     /**
      * Return the extension of the file associated with the document
      */
     public function getExtension();
-    
+
     /**
      * Returns the size of the file type in an appropriate format.
      *

--- a/code/interface/DMSInterface.php
+++ b/code/interface/DMSInterface.php
@@ -32,6 +32,8 @@ interface DMSInterface
      *
      * Returns a number of Document objects based on the a search by tags. You can search by category alone,
      * by tag value alone, or by both. I.e: getByTag("fruits",null); getByTag(null,"banana"); getByTag("fruits","banana")
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      * @abstract
      * @param null $category The metadata category to search for
      * @param null $value The metadata value to search for

--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -298,6 +298,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * 					multi-value or single-value (optional)
      *
      * @return DMSDocument
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function addTag($category, $value, $multiValue = true)
     {
@@ -350,6 +352,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * @param string $value
      *
      * @return DataList
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     protected function getTagsObjects($category, $value = null)
     {
@@ -371,6 +375,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * @param string $value value of the tag to get
      *
      * @return array Strings of all the tags or null if there is no match found
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function getTagsList($category, $value = null)
     {
@@ -402,6 +408,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * @param string $value Value to remove
      *
      * @return DMSDocument
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function removeTag($category, $value = null)
     {
@@ -428,6 +436,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
      * Deletes all tags associated with this Document.
      *
      * @return DMSDocument
+     *
+     * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
      */
     public function removeAllTags()
     {

--- a/code/model/DMSTag.php
+++ b/code/model/DMSTag.php
@@ -4,6 +4,7 @@
  * Hold a set of metadata category/value tags associated with a DMSDocument
  *
  * @package dms
+ * @deprecated 2.0 Will be removed in future in favour of using silverstripe/taxonomy
  */
 class DMSTag extends DataObject
 {


### PR DESCRIPTION
Issue: #99 

The following classes will be removed in 2.0.0:

* `DMSTag`

The following methods will be removed:

### DMSInterface / DMS

* `::getByTag`

### DMSDocumentInterface / DMSDocument

* `::addTag`
* `::getTagsList`
* `::removeTag`
* `::removeAllTags`

See #124 for the 2.0 related changes.
