### PR TITLE
FIX Remove add existing autocompleter for document sets on a page

### DIFF
--- a/code/extensions/DMSSiteTreeExtension.php
+++ b/code/extensions/DMSSiteTreeExtension.php
@@ -24,6 +24,8 @@ class DMSSiteTreeExtension extends DataExtension
         );
         $gridField->addExtraClass('documentsets');
 
+        $gridField->getConfig()->removeComponentsByType('GridFieldAddExistingAutocompleter');
+
         $fields->addFieldToTab(
             'Root.Document Sets (' . $this->owner->DocumentSets()->count() . ')',
             $gridField


### PR DESCRIPTION
Document sets should only have one Page, they shouldn't be able to be added to multiple Pages.

This PR removes the autocompleter that is added by the relation editor config.