### PR TITLE
NEW pages link to document sets

### DIFF
--- a/javascript/DMSGridField.js
+++ b/javascript/DMSGridField.js
@@ -11,5 +11,14 @@
         return false;
       }
     });
+
+    $('.ss-gridfield-item a.dms-doc-sets-link').entwine({
+      onclick: function (e){
+        // Prevent the initial flash of the gridfield's edit form
+        e.preventDefault();
+        document.location.href=this.attr('href');
+        return false;
+      }
+    });
   });
 }(jQuery));

--- a/tests/cms/DMSDocumentAdminTest.php
+++ b/tests/cms/DMSDocumentAdminTest.php
@@ -57,4 +57,17 @@ class DMSDocumentAdminTest extends FunctionalTest
         $this->assertContains('Home Test Page', $result);
         $this->assertContains('About Us Test Page', $result);
     }
+
+    /**
+     * Checks that the document sets GridField has a data column which links to the DocumentSets tab on
+     * the actual page in the CMS
+     */
+    public function testDocumentSetsGridFieldHasLinkToCMSPageEditor()
+    {
+        $result = (string)$this->get('admin/documents/DMSDocumentSet')->getBody();
+        $this->assertContains(
+            "<a class='dms-doc-sets-link'",
+            $result
+        );
+    }
 }


### PR DESCRIPTION
UX improvement > Clicking a page in the GridField on the DocumentSets tab of the DMSDocumentAdmin model admin takes you straight through to the document set tab of that page. 

Resolves #152