### PR TITLE
FIX Remove "Page" literal field when editing a doc set in a page context. Simplify exception test.

### DIFF
--- a/code/model/DMSDocumentSet.php
+++ b/code/model/DMSDocumentSet.php
@@ -117,8 +117,12 @@ class DMSDocumentSet extends DataObject
                     $gridFieldConfig->addComponent($sortableComponent);
                 }
 
-                $field = $fields->fieldByName('Root.Main.PageID');
-                $field->setTitle(_t('DMSDocumentSet.SHOWONPAGE', 'Show on page'));
+                // Don't show which page this is if we're already editing within a page context
+                if (Controller::curr() instanceof CMSPageEditController) {
+                    $fields->removeByName('PageID');
+                } else {
+                    $fields->fieldByName('Root.Main.PageID')->setTitle(_t('DMSDocumentSet.SHOWONPAGE', 'Show on page'));
+                }
 
                 $gridFieldConfig->getComponentByType('GridFieldDataColumns')
                     ->setDisplayFields($self->getDocumentDisplayFields())

--- a/tests/DMSDocumentSetTest.php
+++ b/tests/DMSDocumentSetTest.php
@@ -194,11 +194,24 @@ class DMSDocumentSetTest extends SapphireTest
      */
     public function testExceptionOnNoTitleGiven()
     {
-        $set = DMSDocumentSet::create(array('Title' => ''));
-        try {
-            $set->write();
-        } catch (ValidationException $e) {
-            throw $e;
-        }
+        DMSDocumentSet::create(array('Title' => ''))->write();
+    }
+
+    /**
+     * Ensure that when editing in a page context that the "page" field is removed, or is labelled "Show on page"
+     * otherwise
+     */
+    public function testPageFieldRemovedWhenEditingInPageContext()
+    {
+        $set = $this->objFromFixture('DMSDocumentSet', 'ds1');
+
+        $fields = $set->getCMSFields();
+        $this->assertInstanceOf('DropdownField', $fields->fieldByName('Root.Main.PageID'));
+
+        $pageController = new CMSPageEditController;
+        $pageController->pushCurrent();
+
+        $fields = $set->getCMSFields();
+        $this->assertNull($fields->fieldByName('Root.Main.PageID'));
     }
 }


### PR DESCRIPTION
Resolves #151 