### PR TITLE
Add undefined/sortablegridfield to Travis test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 before_script:
   - composer self-update || true
   - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/build/ss
+  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/build/ss --require undefinedoffset/sortablegridfield:0.6.9
   - cd ~/build/ss
   - composer install
 


### PR DESCRIPTION
Ensures that tests are not skipped when the module is not installed.