### PR TITLE
FIX Redirect back to documents tab after uploading a document

### DIFF
--- a/code/cms/DMSDocumentAddController.php
+++ b/code/cms/DMSDocumentAddController.php
@@ -199,7 +199,7 @@ class DMSDocumentAddController extends LeftAndMain
                     'edit'
                 );
             }
-            return $modelAdmin->Link('DMSDocumentSet');
+            return $modelAdmin->Link();
         }
 
         return Controller::join_links(


### PR DESCRIPTION
Unless you are within a document set or page context.

Fixes #169 