### PR TITLE
fix page edit link slug

### DIFF
--- a/code/cms/DMSDocumentAddController.php
+++ b/code/cms/DMSDocumentAddController.php
@@ -211,8 +211,8 @@ class DMSDocumentAddController extends LeftAndMain
     {
         return Controller::join_links(
             CMSPageEditController::singleton()->getEditForm($pageId)->FormAction(),
-            'field/Document Sets/item',
-            $documentSetId
+            'field/DocumentSets/item',
+            (int) $documentSetId
         );
     }
 


### PR DESCRIPTION
After uploading a file and clicking on 'done', the site throws a 404 due to the incurrect url.