### PR TITLE
Revert "fix page history: remove DMSSiteTreeExtension.getDocumentSets()"

### DIFF
--- a/code/DMS.php
+++ b/code/DMS.php
@@ -151,7 +151,7 @@ class DMS extends Object implements DMSInterface
 
     public function getDocumentSetsByPage(SiteTree $page)
     {
-        return $page->DocumentSets();
+        return $page->getDocumentSets();
     }
 
     /**

--- a/code/extensions/DMSSiteTreeExtension.php
+++ b/code/extensions/DMSSiteTreeExtension.php
@@ -55,14 +55,11 @@ class DMSSiteTreeExtension extends DataExtension
     /**
      * Get a list of document sets for the owner page
      *
-     * @deprecated 3.0 Use DocumentSets() instead.
-     *
      * @return ArrayList
      */
     public function getDocumentSets()
     {
-        Deprecation::notice('3.0', 'Use DocumentSets() instead');
-        return $this->owner->hasManyComponent('DocumentSets');
+        return $this->owner->DocumentSets();
     }
 
     /**
@@ -74,7 +71,7 @@ class DMSSiteTreeExtension extends DataExtension
     {
         $documents = ArrayList::create();
 
-        foreach ($this->owner->DocumentSets() as $documentSet) {
+        foreach ($this->getDocumentSets() as $documentSet) {
             /** @var DocumentSet $documentSet */
             $documents->merge($documentSet->getDocuments());
         }

--- a/templates/Includes/DocumentSets.ss
+++ b/templates/Includes/DocumentSets.ss
@@ -1,6 +1,6 @@
-<% if $DocumentSets %>
+<% if $getDocumentSets %>
     <div class="documentsets">
-        <% loop $DocumentSets %>
+        <% loop $getDocumentSets %>
             <% include DocumentSet %>
         <% end_loop %>
     </div>

--- a/tests/DMSDocumentSetTest.php
+++ b/tests/DMSDocumentSetTest.php
@@ -50,9 +50,9 @@ class DMSDocumentSetTest extends SapphireTest
         $ds2 = $this->objFromFixture('DMSDocumentSet', 'ds2');
         $ds3 = $this->objFromFixture('DMSDocumentSet', 'ds3');
 
-        $this->assertCount(0, $s4->DocumentSets(), 'Page 4 has no document sets associated');
-        $this->assertCount(2, $s1->DocumentSets(), 'Page 1 has 2 document sets');
-        $this->assertEquals(array($ds1->ID, $ds2->ID), $s1->DocumentSets()->column('ID'));
+        $this->assertCount(0, $s4->getDocumentSets(), 'Page 4 has no document sets associated');
+        $this->assertCount(2, $s1->getDocumentSets(), 'Page 1 has 2 document sets');
+        $this->assertEquals(array($ds1->ID, $ds2->ID), $s1->getDocumentSets()->column('ID'));
     }
 
     /**

--- a/tests/DMSEmbargoTest.php
+++ b/tests/DMSEmbargoTest.php
@@ -142,7 +142,7 @@ class DMSEmbargoTest extends SapphireTest
         $doc->Folder = "0";
         $dID = $doc->write();
 
-        $s1->DocumentSets()->first()->getDocuments()->add($doc);
+        $s1->getDocumentSets()->first()->getDocuments()->add($doc);
 
         $s1->publish('Stage', 'Live');
         $s1->doPublish();

--- a/tests/tasks/MigrateToDocumentSetsTaskTest.php
+++ b/tests/tasks/MigrateToDocumentSetsTaskTest.php
@@ -65,9 +65,9 @@ class MigrateToDocumentSetsTaskTest extends SapphireTest
         $this->assertContains('Skipped: already has a set: 1', $result);
 
         // Test that some of the relationship records were written correctly
-        $this->assertCount(1, $firstPageSets = $this->objFromFixture('SiteTree', 'one')->DocumentSets());
+        $this->assertCount(1, $firstPageSets = $this->objFromFixture('SiteTree', 'one')->getDocumentSets());
         $this->assertSame('Default', $firstPageSets->first()->Title);
-        $this->assertCount(1, $this->objFromFixture('SiteTree', 'two')->DocumentSets());
+        $this->assertCount(1, $this->objFromFixture('SiteTree', 'two')->getDocumentSets());
 
         // With dryrun enabled and being run the second time, nothing should be done
         $result = $this->runTask(array('action' => 'create-default-document-set', 'dryrun' => '1'));


### PR DESCRIPTION
Reverts silverstripe/silverstripe-dms#206
Have already merged into master (current alias for `2.2.x-dev`), but this change added a deprecation which requires a minor release (i.e. `2.2`), and so the `2.1` branch (target of this `revert`) should not contain it.