### PR TITLE
update gridfieldextensions vendor and version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "silverstripe/framework": "~3.1",
         "silverstripe/cms": "~3.1",
-        "silverstripe-australia/gridfieldextensions": "^1.1.0"
+        "symbiote/silverstripe-gridfieldextensions": "^2.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This is to make sure that older DMS installations work with current versions of other modules that also require gridfieldextensions