### PR TITLE
Add support for GridfieldOrderableRows

### DIFF
--- a/code/model/DMSDocumentSet.php
+++ b/code/model/DMSDocumentSet.php
@@ -112,6 +112,8 @@ class DMSDocumentSet extends DataObject
 
                 if (class_exists('GridFieldSortableRows')) {
                     $gridFieldConfig->addComponent(new GridFieldSortableRows('DocumentSort'));
+                } elseif (class_exists('GridFieldOrderableRows')) {
+                    $gridFieldConfig->addComponent(new GridFieldOrderableRows('DocumentSort'));
                 }
 
                 // Don't show which page this is if we're already editing within a page context


### PR DESCRIPTION
GridfieldExtensions' [GridfieldOrderableRows](https://github.com/symbiote/silverstripe-gridfieldextensions) is functionally quite similar (if not identical) to GridFieldSortableRows, and not all developers may want to support both modules.  This commit adds fallback support for sorting Document Sets using GridfieldOrderableRows if it is installed, and GridFieldSortableRows is not.

To test:
1. Uninstall GridFieldSortableRows (or start with an install without it)
2. Install GridFieldExtensions
3. Create/Open a Document Set
4. Make sure there are multiple files within.
5. Drag/drop reorder without errors