### PR TITLE
Save default DownloadBehaviour on a DMSDocument when initially uploading a new one

### DIFF
--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -1011,9 +1011,11 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
             $possibleBehaviors = $this->dbObject('DownloadBehavior')
                 ->enumValues();
 
-            $behavior = $possibleBehaviors[$defaultDownloadBehaviour];
-            if ($behavior) {
-                $this->DownloadBehavior = $behavior;
+            if (array_key_exists($defaultDownloadBehaviour, $possibleBehaviors)) {
+                $behavior = $possibleBehaviors[$defaultDownloadBehaviour];
+                if ($behavior) {
+                    $this->DownloadBehavior = $behavior;
+                }
             }
         }
     }

--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -1004,7 +1004,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
             $this->LastEditedByID = $currentUserID;
         }
 
-        // make sure default DownloadBehavior is respected when writing since
+        // make sure default DownloadBehavior is respected when initially writing document
+        // in case the default in the enum is different than what's set in an outside config
         $defaultDownloadBehaviour = Config::inst()->get('DMSDocument', 'default_download_behaviour');
         if ($this->DownloadBehavior == null && !empty($defaultDownloadBehaviour)) {
             $possibleBehaviors = $this->dbObject('DownloadBehavior')

--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -235,7 +235,7 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
             $this->ViewCount = $count;
 
             DB::query("UPDATE \"DMSDocument\" SET \"ViewCount\"='$count' WHERE \"ID\"={$this->ID}");
-            
+
             $this->extend('trackView');
         }
 
@@ -1002,6 +1002,18 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
                 $this->CreatedByID = $currentUserID;
             }
             $this->LastEditedByID = $currentUserID;
+        }
+
+        // make sure default DownloadBehavior is respected when writing since
+        $defaultDownloadBehaviour = Config::inst()->get('DMSDocument', 'default_download_behaviour');
+        if ($this->DownloadBehavior == null && !empty($defaultDownloadBehaviour)) {
+            $possibleBehaviors = $this->dbObject('DownloadBehavior')
+                ->enumValues();
+
+            $behavior =$possibleBehaviors[$defaultDownloadBehaviour];
+            if ($behavior) {
+                $this->DownloadBehavior = $behavior;
+            }
         }
     }
 

--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -1010,7 +1010,7 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
             $possibleBehaviors = $this->dbObject('DownloadBehavior')
                 ->enumValues();
 
-            $behavior =$possibleBehaviors[$defaultDownloadBehaviour];
+            $behavior = $possibleBehaviors[$defaultDownloadBehaviour];
             if ($behavior) {
                 $this->DownloadBehavior = $behavior;
             }


### PR DESCRIPTION
I needed to change the default to be "open" rather than "download". I set this

```
DMSDocument:
  default_download_behaviour: 'open'
```

but noticed that when uploading new documents the default state from the enum of the field was written rather than the default option set in my config. I added code in onBeforeWrite to write the default if set. 