### PR TITLE
FIX: Ensure Version gridfield has correct field formatting  and variables

### DIFF
--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -820,22 +820,26 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
                 new GridFieldDataColumns(),
                 new GridFieldPaginator(30)
             );
+
+            $link = $this->owner->Link();
+            $filenameWithoutID = $this->owner->FilenameWithoutID;
+            
             $versionsGridFieldConfig->getComponentByType('GridFieldDataColumns')
                 ->setDisplayFields(Config::inst()->get('DMSDocument_versions', 'display_fields'))
                 ->setFieldFormatting(
                     array(
-                        'FilenameWithoutID' => '<a target="_blank" class="file-url" href="$Link">'
-                            . '$FilenameWithoutID</a>'
+                        'FilenameWithoutID' => "<a target=\"_blank\" class=\"file-url\" href=\"$link\">"
+                            . "$filenameWithoutID</a>"
                     )
                 );
 
             $versionsGrid =  GridField::create(
                 'Versions',
                 _t('DMSDocument.Versions', 'Versions'),
-                $this->getVersions(),
+                $this->owner->getVersions(),
                 $versionsGridFieldConfig
             );
-            $this->addActionPanelTask('find-versions', 'Versions');
+            $this->owner->addActionPanelTask('find-versions', 'Versions');
         }
 
         $embargoValue = 'None';

--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -821,8 +821,8 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
                 new GridFieldPaginator(30)
             );
 
-            $link = $this->owner->Link();
-            $filenameWithoutID = $this->owner->FilenameWithoutID;
+            $link = $this->Link();
+            $filenameWithoutID = $this->FilenameWithoutID;
             
             $versionsGridFieldConfig->getComponentByType('GridFieldDataColumns')
                 ->setDisplayFields(Config::inst()->get('DMSDocument_versions', 'display_fields'))


### PR DESCRIPTION
With DMSDocument versioning enabled, the getCMSFields Versions Action Panel will generate errors because: 
- Uses single quotes with inline variables rather then double quotes
- `$Link` and `$FilenameWithoutID` are not defined anywhere in this method