### PR TITLE
FIX: Ensure Version gridfield has correct field formatting and variables

### DIFF
--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -820,12 +820,12 @@ class DMSDocument extends DataObject implements DMSDocumentInterface
                 new GridFieldDataColumns(),
                 new GridFieldPaginator(30)
             );
+
             $versionsGridFieldConfig->getComponentByType('GridFieldDataColumns')
                 ->setDisplayFields(Config::inst()->get('DMSDocument_versions', 'display_fields'))
                 ->setFieldFormatting(
                     array(
-                        'FilenameWithoutID' => '<a target="_blank" class="file-url" href="$Link">'
-                            . '$FilenameWithoutID</a>'
+                        'FilenameWithoutID' => '<a target=\"_blank\" class=\"file-url\" href=\"$Link\">$FilenameWithoutID</a>'
                     )
                 );
 


### PR DESCRIPTION
With DMSDocument versioning enabled, the getCMSFields Versions Action Panel will generate errors because the string being passed for the field formatting fails when it is eval()'d